### PR TITLE
Fix: Implementar oclusión correcta de paredes en renderizado isométrico

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -42,9 +42,11 @@ export default class GameScene extends Phaser.Scene {
     document.body.classList.add('game-active');
 
     // Graphics objects for the map — clipped to play area
-    this._tileGfx   = this.add.graphics();
-    this._entityGfx = this.add.graphics().setDepth(100);
-    this._fogGfx    = this.add.graphics().setDepth(500);
+    this._tileGfx      = this.add.graphics();           // Floor tiles
+    this._wallBackGfx  = this.add.graphics().setDepth(50); // Walls behind player
+    this._entityGfx    = this.add.graphics().setDepth(100); // Entities (players, enemies, items)
+    this._wallFrontGfx = this.add.graphics().setDepth(150); // Walls in front of player
+    this._fogGfx       = this.add.graphics().setDepth(500); // Fog (top)
 
     // Apply a rectangular mask so map never bleeds into side panels or top bar
     const maskShape = this.make.graphics({ add: false });
@@ -52,7 +54,9 @@ export default class GameScene extends Phaser.Scene {
     maskShape.fillRect(playX, playY, playW, playH);
     const mask = maskShape.createGeometryMask();
     this._tileGfx.setMask(mask);
+    this._wallBackGfx.setMask(mask);
     this._entityGfx.setMask(mask);
+    this._wallFrontGfx.setMask(mask);
     this._fogGfx.setMask(mask);
 
     // Transition overlay (black rect, fades in/out)
@@ -72,7 +76,8 @@ export default class GameScene extends Phaser.Scene {
       left:  Phaser.Input.Keyboard.KeyCodes.A,
       right: Phaser.Input.Keyboard.KeyCodes.D,
       sword: Phaser.Input.Keyboard.KeyCodes.E,
-      full:  Phaser.Input.Keyboard.KeyCodes.F
+      full:  Phaser.Input.Keyboard.KeyCodes.F,
+      sprint: Phaser.Input.Keyboard.KeyCodes.SHIFT
     });
 
     this.input.keyboard.on('keydown-F', () => {
@@ -205,20 +210,21 @@ export default class GameScene extends Phaser.Scene {
   }
 
   _loadLevel(levelId, lives) {
-    if (this._tileGfx)   this._tileGfx.clear();
-    if (this._entityGfx) this._entityGfx.clear();
-    if (this._fogGfx)    this._fogGfx.clear();
-
+    if (this._tileGfx)      this._tileGfx.clear();
+    if (this._wallBackGfx)  this._wallBackGfx.clear();
+    if (this._wallFrontGfx) this._wallFrontGfx.clear();
+    if (this._entityGfx)    this._entityGfx.clear();
+    if (this._fogGfx)       this._fogGfx.clear();
     this.mapData = LEVELS[levelId];
     this.levelId = levelId;
     this.tiles   = this.mapData.tiles.map(row => [...row]);
 
-    // Difficulty scaling per level
-    const diff = { 1: { visionR: 4, trapMult: 1.0, enemyMult: 1.0 },
-                   2: { visionR: 3, trapMult: 1.5, enemyMult: 1.4 },
-                   3: { visionR: 3, trapMult: 2.2, enemyMult: 2.0 },
-                   4: { visionR: 3, trapMult: 2.5, enemyMult: 2.2 },
-                   5: { visionR: 2, trapMult: 3.0, enemyMult: 2.5 } }[levelId] || { visionR: 3, trapMult: 1, enemyMult: 1 };
+    // Difficulty scaling per level (reduced vision radius for challenge)
+    const diff = { 1: { visionR: 3.0, trapMult: 1.0, enemyMult: 1.0 },
+                   2: { visionR: 2.5, trapMult: 1.5, enemyMult: 1.4 },
+                   3: { visionR: 2.5, trapMult: 2.2, enemyMult: 2.0 },
+                   4: { visionR: 2.0, trapMult: 2.5, enemyMult: 2.2 },
+                   5: { visionR: 1.8, trapMult: 3.0, enemyMult: 2.5 } }[levelId] || { visionR: 2.5, trapMult: 1, enemyMult: 1 };
 
     this.player = new Player(this.mapData.entrance.x, this.mapData.entrance.y);
     this.player.lives = lives;
@@ -229,7 +235,7 @@ export default class GameScene extends Phaser.Scene {
     const scaledEnemies = this.mapData.enemies.map(e => ({ ...e, speed: e.speed * diff.enemyMult }));
 
     this.fog      = new FogOfWarManager(this._fogGfx, this.mapData.width, this.mapData.height, diff.visionR);
-    this.renderer = new IsometricRenderer(this._tileGfx, this._entityGfx, this.mapData, this.scale.width, this.scale.height, this._panelW);
+    this.renderer = new IsometricRenderer(this._tileGfx, this._wallBackGfx, this._wallFrontGfx, this._entityGfx, this.mapData, this.scale.width, this.scale.height, this._panelW);
 
     this.trapManager   = new TrapManager(scaledTraps);
     this.enemyManager  = new EnemyManager(scaledEnemies);
@@ -296,28 +302,43 @@ export default class GameScene extends Phaser.Scene {
     if (this._transitioning) return;
     this.damageThisFrame = false;
 
-    // --- Player input ---
+    // --- Player input (continuous movement) ---
     const dir = this._getInputDirection();
-    if (dir) {
-      const moved = this.player.tryMove(dir, (nx, ny) => this._isWalkable(nx, ny));
-      if (moved) {
-        // Track last direction for sword slash
-        const dirMap = { UP: [0,-1], DOWN: [0,1], LEFT: [-1,0], RIGHT: [1,0] };
-        [this._lastDirDx, this._lastDirDy] = dirMap[dir];
-        this._playSound('step');
-        this.fog.recalculate(this.player.gridX, this.player.gridY);
-        this._onPlayerMoved();
-      }
+    this.player.setMovement(dir, (nx, ny) => this._isWalkable(nx, ny));
+    
+    // Update player movement
+    const moveResult = this.player.update(delta, (nx, ny) => this._isWalkable(nx, ny));
+    
+    // If player entered a new cell, trigger events
+    if (moveResult.enteredNewCell) {
+      this._onPlayerMoved();
+      this.fog.recalculate(this.player.gridX, this.player.gridY);
+    }
+    
+    // Update facing for sword slash
+    const dirMap = { UP: [0,-1], DOWN: [0,1], LEFT: [-1,0], RIGHT: [1,0] };
+    if (this.player.facing && dirMap[this.player.facing]) {
+      [this._lastDirDx, this._lastDirDy] = dirMap[this.player.facing];
     }
 
     // Sword use
-    const mc = window.mobileCtrl || {};
+    const mc= window.mobileCtrl || {};
     const swordPressed = Phaser.Input.Keyboard.JustDown(this.wasd.sword) || mc.sword;
     if (mc.sword) mc.sword = false;
+    
+    // Sprint activation (Shift key or mobile sprint button)
+    const sprintPressed = Phaser.Input.Keyboard.JustDown(this.wasd.sprint) || mc.sprint;
+    if (mc.sprint) mc.sprint = false;
+    if (sprintPressed) {
+      if (this.player.activateSprint()) {
+        this._playSound('sprint_start');
+      }
+    }
+    
     if (swordPressed) {
       if (this.player.swordUses > 0) {
         const trap = this.trapManager.getAdjacentTrap(this.player.gridX, this.player.gridY);
-        // Determine slash direction from last movement
+        // Determine slash direction from facing
         const dx = this._lastDirDx || 1;
         const dy = this._lastDirDy || 0;
         this.renderer.triggerSwordFlash(dx, dy);
@@ -338,22 +359,20 @@ export default class GameScene extends Phaser.Scene {
       }
     }
 
-    this.player.update(delta);
-
     // --- Update systems ---
     this.fog.update(delta);
     this.trapManager.update(delta);
-    this.enemyManager.update(delta);
+    this.enemyManager.update(delta, this.player.visualX, this.player.visualY, (nx, ny) => this._isWalkable(nx, ny));
     this.mineManager.update(delta);
 
-    // --- Collision checks ---
+    // --- Collision checks (use floating-point positions for smooth continuous movement) ---
     if (!this.damageThisFrame) {
-      if (this.trapManager.checkCollision(this.player.gridX, this.player.gridY)) {
+      if (this.trapManager.checkCollision(this.player.visualX, this.player.visualY)) {
         this._damagePlayer();
       }
     }
     if (!this.damageThisFrame) {
-      if (this.enemyManager.checkCollision(this.player.gridX, this.player.gridY)) {
+      if (this.enemyManager.checkCollision(this.player.visualX, this.player.visualY)) {
         this._damagePlayer();
       }
     }
@@ -368,7 +387,7 @@ export default class GameScene extends Phaser.Scene {
 
     // --- Render ---
     this.renderer.followPlayer(this.player.visualX, this.player.visualY);
-    this.renderer.drawMap(this.fog, this.tiles, delta);
+    this.renderer.drawMap(this.fog, this.tiles, this.player.visualX, this.player.visualY, delta);
     this.renderer.clearEntities();
     this._renderEntities();
     if (this.renderer.swordFlash > 0) {
@@ -387,24 +406,29 @@ export default class GameScene extends Phaser.Scene {
     const w = this.wasd;
     const mc = window.mobileCtrl || {};
 
-    if (Phaser.Input.Keyboard.JustDown(up)    || Phaser.Input.Keyboard.JustDown(w.up)    || mc.up)    { mc.up    = false; return 'UP'; }
-    if (Phaser.Input.Keyboard.JustDown(down)  || Phaser.Input.Keyboard.JustDown(w.down)  || mc.down)  { mc.down  = false; return 'DOWN'; }
-    if (Phaser.Input.Keyboard.JustDown(left)  || Phaser.Input.Keyboard.JustDown(w.left)  || mc.left)  { mc.left  = false; return 'LEFT'; }
-    if (Phaser.Input.Keyboard.JustDown(right) || Phaser.Input.Keyboard.JustDown(w.right) || mc.right) {
-      mc.right = false; return 'RIGHT';
-    }
-    return null;
+    // Return direction if key/button is held down (not just pressed)
+    if (up.isDown || w.up.isDown || mc.up) return 'UP';
+    if (down.isDown || w.down.isDown || mc.down) return 'DOWN';
+    if (left.isDown || w.left.isDown || mc.left) return 'LEFT';
+    if (right.isDown || w.right.isDown || mc.right) return 'RIGHT';
+    
+    return null; // No movement
   }
 
   _isWalkable(nx, ny) {
-    if (nx < 0 || ny < 0 || nx >= this.mapData.width || ny >= this.mapData.height) return false;
-    const tile = this.tiles[ny][nx];
+    // Validate inputs are valid numbers
+    if (typeof nx !== 'number' || typeof ny !== 'number' || isNaN(nx) || isNaN(ny)) return false;
+    // Round to nearest tile since enemies use floating point positions
+    const tileX = Math.round(nx);
+    const tileY = Math.round(ny);
+    if (tileX < 0 || tileY < 0 || tileX >= this.mapData.width || tileY >= this.mapData.height) return false;
+    const tile = this.tiles[tileY][tileX];
     if (tile === T.WALL) return false;
     if (tile === T.DOOR_CLOSED) {
       // Auto-use key if player has one
       if (this.player.hasKey()) {
         this.player.useKey();
-        this.tiles[ny][nx] = T.DOOR_OPEN;
+        this.tiles[tileY][tileX] = T.DOOR_OPEN;
         this._playSound('door_open');
         return true;
       }
@@ -430,7 +454,7 @@ export default class GameScene extends Phaser.Scene {
     const mine = this.mineManager.tryActivate(px, py);
     if (mine) {
       this._playSound('mine_activate');
-      this.game.events.emit('hud-hint', '💣 ¡Mina activada! ¡Aléjate en 3 segundos!');
+      this.game.events.emit('hud-hint', '💣 ¡Mina activada! ¡Aléjate en 2 segundos!');
     }
 
     // Switch activation
@@ -547,7 +571,7 @@ export default class GameScene extends Phaser.Scene {
 
   _renderEntities() {
     // Use visual (interpolated) position for smooth movement
-    this.renderer.drawEntity(this.player.visualX, this.player.visualY, 'PLAYER');
+    this.renderer.drawEntity(this.player.visualX, this.player.visualY, 'PLAYER', this.player.facing);
     
     // Draw equipped items and active inventory around player
     this.renderer.drawPlayerEquipment(
@@ -572,7 +596,7 @@ export default class GameScene extends Phaser.Scene {
       const gx = Math.round(enemy.posX);
       const gy = Math.round(enemy.posY);
       if (this.fog.isVisible(gx, gy)) {
-        this.renderer.drawEntity(enemy.posX, enemy.posY, 'ENEMY', this.levelId, enemy.id);
+        this.renderer.drawEntity(enemy.posX, enemy.posY, 'ENEMY', enemy.type, enemy.id);
       }
     }
 

--- a/src/systems/IsometricRenderer.js
+++ b/src/systems/IsometricRenderer.js
@@ -30,8 +30,10 @@ const C = {
 };
 
 export default class IsometricRenderer {
-  constructor(tileGfx, entityGfx, mapData, sceneWidth, sceneHeight, panelW = 188) {
+  constructor(tileGfx, wallBackGfx, wallFrontGfx, entityGfx, mapData, sceneWidth, sceneHeight, panelW = 188) {
     this.tileGraphics = tileGfx;
+    this.wallBackGraphics = wallBackGfx;
+    this.wallFrontGraphics = wallFrontGfx;
     this.entityGraphics = entityGfx;
     this.mapData = mapData;
     this.sceneWidth = sceneWidth;
@@ -131,7 +133,7 @@ export default class IsometricRenderer {
     const inventory = player.inventory || [];
     let yOffset = -30;
     for (const item of inventory) {
-      // Blink if time is low (less than 3 seconds remaining)
+      // Blink if time is low (less than 2 seconds remaining)
       const timeLeft = item.expiresAt ? item.expiresAt - currentTime : Infinity;
       const isLowTime = timeLeft < 3000;
       const shouldShow = !isLowTime || Math.floor(currentTime / 300) % 2 === 0;
@@ -181,10 +183,15 @@ export default class IsometricRenderer {
     return { x: x + TILE_W / 2, y: y + TILE_H / 2 };
   }
 
-  drawMap(fogManager, tiles, delta = 0) {
+  drawMap(fogManager, tiles, playerGx, playerGy, delta = 0) {
     if (this.swordFlash > 0) this.swordFlash -= delta;
     this.tileGraphics.clear();
+    this.wallBackGraphics.clear();
+    this.wallFrontGraphics.clear();
     const { width, height } = this.mapData;
+    
+    // Player's isometric position (for depth comparison)
+    const playerSum = Math.floor(playerGx) + Math.floor(playerGy);
 
     // Isometric painter's order: back-to-front (low gx+gy first)
     for (let sum = 0; sum < width + height - 1; sum++) {
@@ -202,7 +209,10 @@ export default class IsometricRenderer {
         const cx = x + TILE_W / 2;
 
         if (tile === 1 || tile === 4) {
-          this._isoWall(cx, y, tile, alpha);
+          // Walls: draw in front layer if they're in front of player, otherwise in back layer
+          const wallSum = gx + gy;
+          const isFront = wallSum > playerSum;
+          this._isoWall(cx, y, tile, alpha, isFront);
         } else {
           this._isoFloor(cx, y, tile, alpha);
         }
@@ -225,13 +235,13 @@ export default class IsometricRenderer {
     let topColor, leftColor, rightColor, symbol = null;
 
     switch (type) {
-      case 2: // ENTRANCE
+      case 2: // ENTRANCE - vibrant green with glow
         topColor   = C.ENT_TOP;
         leftColor  = C.ENT_LEFT;
         rightColor = C.ENT_RIGHT;
         symbol = 'entrance';
         break;
-      case 3: // EXIT
+      case 3: // EXIT - bright red with pulsing glow
         topColor   = C.EXIT_TOP;
         leftColor  = C.EXIT_LEFT;
         rightColor = C.EXIT_RIGHT;
@@ -273,28 +283,85 @@ export default class IsometricRenderer {
       { x: cx - hw * 0.5, y: ty + hh * 0.7 }
     ], true);
 
-    // Symbols
+    // Enhanced 3D symbols
     if (symbol === 'entrance') {
-      g.fillStyle(0xffffff, alpha * 0.85);
-      g.fillTriangle(cx, ty + TILE_H - 6, cx - 6, ty + 8, cx + 6, ty + 8);
-      g.fillStyle(0x000000, alpha * 0.2);
-      g.fillTriangle(cx + 1, ty + TILE_H - 5, cx - 5, ty + 9, cx + 7, ty + 9);
-    } else if (symbol === 'exit') {
-      g.fillStyle(0xffffff, alpha * 0.9);
-      g.fillCircle(cx, ty + hh, 5);
-      g.fillStyle(0xff1744, alpha);
-      g.fillCircle(cx, ty + hh, 3);
-      g.fillStyle(0xffffff, alpha * 0.9);
+      const t = Date.now();
+      const pulse = Math.sin(t * 0.003) * 0.2;
+      const centerY = ty + hh; // Center of diamond
+      
+      // Glowing aura around entrance
+      g.fillStyle(0x66bb6a, alpha * (0.15 + pulse));
+      g.fillCircle(cx, centerY, 18);
+      g.fillStyle(0x81c784, alpha * (0.25 + pulse));
+      g.fillCircle(cx, centerY, 12);
+      
+      // Arrow symbol pointing up (entrance direction)
+      g.fillStyle(0xffffff, alpha * 0.95);
+      g.fillTriangle(cx, centerY - 8, cx - 10, centerY + 6, cx + 10, centerY + 6);
+      
+      // Arrow highlight/3D effect
+      g.fillStyle(0xc8e6c9, alpha * 0.6);
+      g.fillTriangle(cx, centerY - 6, cx - 8, centerY + 4, cx + 8, centerY + 4);
+      
+      // Shadow underneath
+      g.fillStyle(0x000000, alpha * 0.25);
+      g.fillTriangle(cx + 1, centerY - 6, cx - 7, centerY + 5, cx + 9, centerY + 5);
+      
+      // Sparkles around entrance
       for (let i = 0; i < 4; i++) {
-        const a = (i / 4) * Math.PI * 2 + Math.PI / 4;
-        g.fillRect(cx + Math.cos(a) * 6 - 1, ty + hh + Math.sin(a) * 4 - 1, 2, 2);
+        const angle = (i / 4) * Math.PI * 2 + t * 0.002;
+        const dist = 14;
+        const sx = cx + Math.cos(angle) * dist;
+        const sy = centerY + Math.sin(angle) * dist * 0.5;
+        g.fillStyle(0xffffff, alpha * (0.7 + pulse));
+        g.fillCircle(sx, sy, 2);
+      }
+    } else if (symbol === 'exit') {
+      const t = Date.now();
+      const pulse = Math.sin(t * 0.004) * 0.25;
+      const centerY = ty + hh; // Center of diamond
+      
+      // Intense glowing aura around exit
+      g.fillStyle(0xff1744, alpha * (0.12 + pulse));
+      g.fillCircle(cx, centerY, 22);
+      g.fillStyle(0xff5252, alpha * (0.22 + pulse));
+      g.fillCircle(cx, centerY, 16);
+      g.fillStyle(0xff6e6e, alpha * (0.32 + pulse));
+      g.fillCircle(cx, centerY, 10);
+      
+      // Center portal effect (larger)
+      g.fillStyle(0xffffff, alpha * 0.95);
+      g.fillCircle(cx, centerY, 7);
+      g.fillStyle(0xff1744, alpha * (0.9 + pulse));
+      g.fillCircle(cx, centerY, 5);
+      g.fillStyle(0xff5252, alpha * 0.7);
+      g.fillCircle(cx, centerY, 3);
+      
+      // Rotating energy rays
+      g.fillStyle(0xffffff, alpha * 0.9);
+      for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2 + t * 0.002 + Math.PI / 4;
+        const dist = 10;
+        const rayX = cx + Math.cos(a) * dist;
+        const rayY = centerY + Math.sin(a) * dist * 0.5;
+        g.fillRect(rayX - 1, rayY - 1, 3, 3);
+      }
+      
+      // Outer energy particles (orbiting)
+      for (let i = 0; i < 6; i++) {
+        const a = (i / 6) * Math.PI * 2 + t * 0.003;
+        const dist = 15;
+        const px = cx + Math.cos(a) * dist;
+        const py = centerY + Math.sin(a) * dist * 0.5;
+        g.fillStyle(0xff8a80, alpha * (0.8 + pulse * 0.8));
+        g.fillCircle(px, py, 2.5);
       }
     }
   }
 
   // ── Isometric wall block — top face + two visible side faces ─────────────────
-  _isoWall(cx, ty, type, alpha) {
-    const g   = this.tileGraphics;
+  _isoWall(cx, ty, type, alpha, isFront = false) {
+    const g   = isFront ? this.wallFrontGraphics : this.wallBackGraphics;
     const hw  = TILE_W / 2;
     const hh  = TILE_H / 2;
     const wh  = WALL_H;
@@ -393,40 +460,134 @@ export default class IsometricRenderer {
 
     // ── Door details ──────────────────────────────────────────────────────────
     if (isDoor) {
-      // Bars on left face
-      g.fillStyle(0x9c27b0, alpha * 0.6);
-      for (let i = 0; i < 2; i++) {
-        const t2 = (i + 1) / 3;
+      const t = Date.now();
+      const pulse = Math.sin(t * 0.005) * 0.15;
+      
+      // Magical glow around door (purple aura)
+      g.fillStyle(0xba68c8, alpha * (0.20 + pulse));
+      g.fillEllipse(cx, ty + hh, hw * 1.4, hh * 1.4);
+      
+      // Vertical bars on left face (prison-style door)
+      g.fillStyle(0x9c27b0, alpha * 0.7);
+      for (let i = 0; i < 3; i++) {
+        const t2 = (i + 1) / 4;
         const bx = left.x  + (bot.x  - left.x)  * t2;
         const by = left.y  + (bot.y  - left.y)   * t2;
-        g.fillRect(bx - 2, by, 4, wh);
-        g.fillStyle(0xce93d8, alpha * 0.3);
-        g.fillRect(bx - 2, by, 1, wh);
-        g.fillStyle(0x9c27b0, alpha * 0.6);
+        g.fillRect(bx - 2.5, by, 5, wh);
+        // Bar highlight
+        g.fillStyle(0xce93d8, alpha * 0.4);
+        g.fillRect(bx - 2.5, by, 1.5, wh);
+        g.fillStyle(0x9c27b0, alpha * 0.7);
       }
-      // Lock on top face
-      g.fillStyle(0xffd54f, alpha * 0.9);
-      g.fillCircle(cx, ty + hh, 4);
-      g.fillStyle(0x000000, alpha * 0.5);
-      g.fillCircle(cx, ty + hh, 2);
+      
+      // Horizontal crossbars
+      g.fillStyle(0x8e24aa, alpha * 0.8);
+      for (let i = 1; i < 3; i++) {
+        const fy = i / 3;
+        const y1 = left.y + wh * fy;
+        const y2 = bot.y + wh * fy;
+        // Draw crossbar across all vertical bars
+        g.fillPoints([
+          { x: left.x,  y: y1 },
+          { x: bot.x,   y: y2 },
+          { x: bot.x,   y: y2 + 3 },
+          { x: left.x,  y: y1 + 3 }
+        ], true);
+      }
+      
+      // Large ornate lock on top face
+      const lockX = cx;
+      const lockY = ty + hh;
+      
+      // Lock base (metallic gold)
+      g.fillStyle(0xffa726, alpha * 0.95);
+      g.fillRect(lockX - 6, lockY - 5, 12, 10);
+      g.fillStyle(0xffb74d, alpha * 0.7);
+      g.fillRect(lockX - 5, lockY - 4, 10, 8);
+      
+      // Lock shackle (U-shaped top)
+      g.lineStyle(4, 0xffa726, alpha * 0.9);
+      g.beginPath();
+      g.arc(lockX, lockY - 5, 6, Math.PI, 0, true);
+      g.strokePath();
+      
+      // Keyhole (glowing)
+      g.fillStyle(0x000000, alpha);
+      g.fillCircle(lockX, lockY, 3);
+      g.fillStyle(0x7c4dff, alpha * (0.8 + pulse));
+      g.fillCircle(lockX, lockY, 2);
+      
+      // Lock shine
+      g.fillStyle(0xffffff, alpha * 0.6);
+      g.fillCircle(lockX - 2, lockY - 2, 1.5);
+      
+      // Magical sparkles around lock
+      for (let i = 0; i < 4; i++) {
+        const angle = (i / 4) * Math.PI * 2 + t * 0.003;
+        const dist = 12;
+        const sx = lockX + Math.cos(angle) * dist;
+        const sy = lockY + Math.sin(angle) * dist * 0.5;
+        g.fillStyle(0xce93d8, alpha * (0.6 + pulse));
+        g.fillCircle(sx, sy, 1.5);
+      }
     }
   }
 
   clearEntities() { this.entityGraphics.clear(); }
 
-  _shadow(cx, cy, rx = 12, ry = 5) {
-    const g = this.entityGraphics;
-    g.fillStyle(0x000000, 0.4);
-    g.fillEllipse(cx, cy + TILE_H * 0.6, rx * 2, ry * 2);
+  _getTileAt(gx, gy) {
+    if (!this.tiles) return 1; // Default to wall if no tiles
+    const { width, height } = this.mapData;
+    // Round to nearest tile since positions are now floating point
+    const tileX = Math.round(gx);
+    const tileY = Math.round(gy);
+    if (tileX < 0 || tileY < 0 || tileX >= width || tileY >= height) return 1;
+    return this.tiles[tileY][tileX];
   }
 
-  drawEntity(gx, gy, colorKey, levelId = 1, entityId = 'e0') {
+  _shadow(cx, cy, gx, gy, rx = 14, ry = 6) {
+    const g = this.entityGraphics;
+    
+    // For continuous movement, we need to check the actual tile the entity is on
+    // Use floor to get the current tile (entities are considered "on" the tile they're in)
+    const currentTileX = Math.floor(gx);
+    const currentTileY = Math.floor(gy);
+    const tileType = this._getTileAt(currentTileX, currentTileY);
+    
+    // Only draw shadow on walkable tiles
+    if (tileType !== 0 && tileType !== 2 && tileType !== 3 && tileType !== 5) {
+      return; // Not a floor tile, skip shadow
+    }
+    
+    // Shadow position - make it more visible and properly offset
+    const shadowOffsetX = 3;
+    const shadowOffsetY = TILE_H * 0.30;  // Slightly separated from sprite
+    const shadowCenterX = cx + shadowOffsetX;
+    const shadowCenterY = cy + shadowOffsetY;
+    
+    // More visible 3-layer shadow that stays within tile bounds
+    // Outer soft shadow
+    g.fillStyle(0x000000, 0.18);
+    g.fillEllipse(shadowCenterX, shadowCenterY, rx * 1.6, ry * 1.6);
+    
+    // Middle shadow
+    g.fillStyle(0x000000, 0.35);
+    g.fillEllipse(shadowCenterX, shadowCenterY, rx * 1.1, ry * 1.1);
+    
+    // Inner core shadow (most visible)
+    g.fillStyle(0x000000, 0.55);
+    g.fillEllipse(shadowCenterX, shadowCenterY, rx * 0.75, ry * 0.75);
+  }
+
+  drawEntity(gx, gy, colorKey, facingOrLevelId = 1, entityId = 'e0') {
     const s  = tileToScreen(gx, gy);
     const cx = s.x + this.offsetX + TILE_W / 2;
     const cy = s.y + this.offsetY + TILE_H / 2;
-    this._shadow(cx, cy);
-    if      (colorKey === 'PLAYER')       this._drawKiroGhost(cx, cy);
-    else if (colorKey === 'ENEMY')        this._drawEnemy(cx, cy, gx, gy, levelId, entityId);
+    
+    // Draw shadow with clipping
+    this._shadow(cx, cy, gx, gy);
+    if      (colorKey === 'PLAYER')       this._drawKiroGhost(cx, cy, facingOrLevelId);
+    else if (colorKey === 'ENEMY')        this._drawEnemy(cx, cy, gx, gy, facingOrLevelId, entityId);
     else if (colorKey === 'ITEM_TORCH')   this._drawTorch(cx, cy);
     else if (colorKey === 'ITEM_HEALTH')  this._drawHealthPotion(cx, cy);
     else if (colorKey === 'ITEM_KEY')     this._drawKey(cx, cy);
@@ -437,16 +598,17 @@ export default class IsometricRenderer {
     else this._drawFallback(cx, cy, 0xffffff);
   }
 
-  _drawEnemy(cx, cy, gx, gy, levelId, entityId) {
-    if (levelId === 1) {
-      this._drawAWSEnemy(cx, cy, gx, gy);
+  _drawEnemy(cx, cy, gx, gy, enemyType, entityId) {
+    // New intelligent maze enemies
+    if (enemyType === 'SKELETON') {
+      this._drawSkeleton(cx, cy);
+    } else if (enemyType === 'MINOTAUR') {
+      this._drawMinotaur(cx, cy);
+    } else if (enemyType === 'SPECTER') {
+      this._drawSpecter(cx, cy);
     } else {
-      const idNum = parseInt(entityId.replace(/\D/g, ''), 10) || 0;
-      const variant = (idNum + gx + gy) % 3;
-      const big = levelId >= 3;
-      if (variant === 0)      this._drawBat(cx, cy, big);
-      else if (variant === 1) this._drawWolf(cx, cy, big);
-      else                    this._drawSpider(cx, cy, big);
+      // Fallback for old enemy types (shouldn't happen)
+      this._drawFallback(cx, cy, 0xff0000);
     }
   }
 
@@ -531,348 +693,480 @@ export default class IsometricRenderer {
     }
   }
 
-  // ── Kiro Ghost ────────────────────────────────────────────────────────────────
-  _drawKiroGhost(cx, cy) {
-    const g = this.entityGraphics, r = 14;
-    // outer glow
-    g.fillStyle(0x7c4dff, 0.15); g.fillCircle(cx, cy-2, r+10);
-    g.fillStyle(0xb39ddb, 0.25); g.fillCircle(cx, cy-2, r+6);
-    // body base
-    g.fillStyle(0xede7f6, 1); g.fillCircle(cx, cy-4, r); g.fillRect(cx-r, cy-4, r*2, r+2);
-    // body shading — right side darker
-    g.fillStyle(0xb39ddb, 0.35); g.fillRect(cx+2, cy-4, r-2, r+2);
-    // wavy bottom
-    const br = r/3;
-    g.fillStyle(0x1a1a2e, 1);
-    for (let i=0;i<3;i++) g.fillCircle(cx-r+br+i*br*2, cy+r-2, br);
-    g.fillStyle(0xede7f6, 1);
-    for (let i=0;i<2;i++) g.fillCircle(cx-r+br*2+i*br*2, cy+r-2, br*0.7);
-    // eyes
-    g.fillStyle(0x7c4dff, 1); g.fillCircle(cx-5, cy-6, 4); g.fillCircle(cx+5, cy-6, 4);
-    g.fillStyle(0xffffff, 0.9); g.fillCircle(cx-4, cy-7, 1.5); g.fillCircle(cx+6, cy-7, 1.5);
-    // highlight on top
-    g.fillStyle(0xffffff, 0.3); g.fillEllipse(cx-3, cy-12, 10, 5);
-  }
-
-  // ── Creature enemies (level 2+) ───────────────────────────────────────────────
-
-  _drawBat(cx, cy, big) {
-    const g = this.entityGraphics, s = big ? 1.5 : 1.0, t = Date.now();
-    const flap = Math.sin(t * 0.015) * 8 * s;
-    // glow
-    g.fillStyle(0x4a0080, 0.25); g.fillCircle(cx, cy, 20*s);
-    // wings
-    g.fillStyle(0x1a0030, 1);
-    g.fillTriangle(cx-2*s, cy, cx-18*s, cy-10*s+flap, cx-12*s, cy+8*s);
-    g.fillTriangle(cx+2*s, cy, cx+18*s, cy-10*s+flap, cx+12*s, cy+8*s);
-    g.fillStyle(0x6a0080, 0.55);
-    g.fillTriangle(cx-2*s, cy, cx-15*s, cy-7*s+flap*0.8, cx-9*s, cy+6*s);
-    g.fillTriangle(cx+2*s, cy, cx+15*s, cy-7*s+flap*0.8, cx+9*s, cy+6*s);
-    // wing veins
-    g.lineStyle(1*s, 0x4a0072, 0.5);
-    g.lineBetween(cx-2*s, cy, cx-14*s, cy-6*s+flap*0.7);
-    g.lineBetween(cx-2*s, cy, cx-10*s, cy+5*s);
-    g.lineBetween(cx+2*s, cy, cx+14*s, cy-6*s+flap*0.7);
-    g.lineBetween(cx+2*s, cy, cx+10*s, cy+5*s);
-    // body
-    g.fillStyle(0x2d0050, 1); g.fillEllipse(cx, cy, 12*s, 14*s);
-    g.fillStyle(0x6a0080, 0.4); g.fillEllipse(cx-2*s, cy-2*s, 5*s, 7*s);
-    // head
-    g.fillStyle(0x1a0030, 1); g.fillCircle(cx, cy-8*s, 6*s);
-    g.fillStyle(0x2d0050, 1); g.fillCircle(cx, cy-8*s, 5*s);
-    // ears
-    g.fillStyle(0x1a0030, 1);
-    g.fillTriangle(cx-4*s, cy-11*s, cx-7*s, cy-19*s, cx-1*s, cy-13*s);
-    g.fillTriangle(cx+4*s, cy-11*s, cx+7*s, cy-19*s, cx+1*s, cy-13*s);
-    g.fillStyle(0xce93d8, 0.5);
-    g.fillTriangle(cx-4*s, cy-12*s, cx-6*s, cy-17*s, cx-2*s, cy-13*s);
-    g.fillTriangle(cx+4*s, cy-12*s, cx+6*s, cy-17*s, cx+2*s, cy-13*s);
-    // eyes
-    g.fillStyle(0xff1744, 1); g.fillCircle(cx-2*s, cy-8*s, 2*s); g.fillCircle(cx+2*s, cy-8*s, 2*s);
-    g.fillStyle(0xff8a80, 0.8); g.fillCircle(cx-2*s, cy-9*s, 0.7*s); g.fillCircle(cx+2*s, cy-9*s, 0.7*s);
-    // fangs
-    g.fillStyle(0xffffff, 0.9);
-    g.fillTriangle(cx-2*s, cy-4*s, cx-1*s, cy-4*s, cx-1.5*s, cy-1*s);
-    g.fillTriangle(cx+1*s, cy-4*s, cx+2*s, cy-4*s, cx+1.5*s, cy-1*s);
-    if (big) { g.fillStyle(0x9c27b0, 0.15+Math.sin(t*0.008)*0.1); g.fillCircle(cx, cy, 26); }
-  }
-
-  _drawWolf(cx, cy, big) {
-    const g = this.entityGraphics, s = big ? 1.5 : 1.0, t = Date.now();
-    const pulse = Math.sin(t * 0.006) * 0.08;
-
-    // Outer glow
-    g.fillStyle(0x1565c0, 0.15 + pulse);
-    g.fillCircle(cx, cy, 22 * s);
-
-    // The Kiro "A" shape — arch with two legs and curved inner arch
-    // Drawn as layered filled polygons to simulate the blue→orange gradient
-
-    // Shadow / depth
-    g.fillStyle(0x0d47a1, 0.5);
-    this._kiroArch(g, cx + 2*s, cy + 2*s, s, 0x0d47a1);
-
-    // Base blue (bottom/legs)
-    this._kiroArch(g, cx, cy, s, 0x1e88e5);
-
-    // Mid blue-cyan layer (lower arch body)
-    g.fillStyle(0x29b6f6, 0.7);
-    this._kiroArchInner(g, cx, cy, s);
-
-    // Green transition (mid arch)
-    g.fillStyle(0x26a69a, 0.55);
-    g.fillEllipse(cx, cy - 4*s, 18*s, 14*s);
-
-    // Yellow-orange (upper arch)
-    g.fillStyle(0xffa726, 0.6);
-    g.fillEllipse(cx, cy - 9*s, 12*s, 10*s);
-
-    // Red-orange peak (very top)
-    g.fillStyle(0xef5350, 0.65);
-    g.fillEllipse(cx, cy - 13*s, 8*s, 7*s);
-
-    // Bright orange highlight at apex
-    g.fillStyle(0xff7043, 0.8);
-    g.fillCircle(cx, cy - 15*s, 3.5*s);
-
-    // Inner arch cutout (the negative space between the legs)
-    g.fillStyle(0x1a1a2e, 1);
-    g.fillEllipse(cx, cy + 2*s, 10*s, 7*s);
-
-    // Leg bottoms — rounded feet
-    g.fillStyle(0x1565c0, 1);
-    g.fillEllipse(cx - 10*s, cy + 8*s, 7*s, 5*s);
-    g.fillEllipse(cx + 10*s, cy + 8*s, 7*s, 5*s);
-
-    // Specular highlight on left side of arch
-    g.fillStyle(0xffffff, 0.15);
-    g.fillEllipse(cx - 5*s, cy - 8*s, 5*s, 12*s);
-
-    if (big) {
-      g.fillStyle(0x42a5f5, 0.12 + pulse);
-      g.fillCircle(cx, cy, 28);
+  // ── Kiro Ghost (超kawaii♡ style) ─────────────────────────────────────────────
+  _drawKiroGhost(cx, cy, facing = 'DOWN') {
+    const g = this.entityGraphics;
+    const r = 16;
+    const t = Date.now();
+    const floatOffset = Math.sin(t * 0.003) * 3; // Gentle floating
+    const bounce = Math.abs(Math.sin(t * 0.004)) * 0.5; // Cute bounce
+    
+    // Base position (floating above ground)
+    const baseY = cy - 10 + floatOffset;
+    
+    // ── Soft pastel aura (kawaii glow) ────────────────────────────────────────
+    const aurapulse = Math.sin(t * 0.005) * 0.1;
+    g.fillStyle(0xe1bee7, 0.12 + aurapulse);
+    g.fillCircle(cx, baseY, r + 14);
+    g.fillStyle(0xf3e5f5, 0.18 + aurapulse);
+    g.fillCircle(cx, baseY, r + 8);
+    
+    // ── Cute round body ───────────────────────────────────────────────────────
+    // Main body (soft white with slight purple tint)
+    g.fillStyle(0xf8f8ff, 1);
+    g.fillCircle(cx, baseY - 2, r);
+    
+    // Pastel purple shading (3D roundness)
+    g.fillStyle(0xede7f6, 0.6);
+    g.fillCircle(cx - 2, baseY + 2, r - 2);
+    
+    // Top highlight (makes it look round and shiny)
+    g.fillStyle(0xffffff, 0.7);
+    g.fillCircle(cx - 4, baseY - 7, r * 0.5);
+    
+    // ── Adorable wavy tail (kawaii style) ─────────────────────────────────────
+    const tailY = baseY + r - 4;
+    const numTails = 3;
+    for (let i = 0; i < numTails; i++) {
+      const wavePhase = (t * 0.005) + (i * 1.2);
+      const waveX = cx + Math.sin(wavePhase) * 2;
+      const tailSize = (r / 2.2) * (1 - i / numTails);
+      
+      // Tail shadow
+      g.fillStyle(0xd1c4e9, 0.4);
+      g.fillCircle(waveX + 1, tailY + i * 4 + 1, tailSize);
+      
+      // Main tail
+      g.fillStyle(0xf8f8ff, 0.95);
+      g.fillCircle(waveX, tailY + i * 4, tailSize);
+      
+      // Tail highlight
+      g.fillStyle(0xffffff, 0.6);
+      g.fillCircle(waveX - 1, tailY + i * 4 - 1, tailSize * 0.5);
     }
-  }
-
-  // Helper: draw the outer Kiro arch shape (two legs + arch top)
-  _kiroArch(g, cx, cy, s, color) {
-    g.fillStyle(color, 1);
-    // Left leg
-    g.fillEllipse(cx - 10*s, cy + 4*s, 8*s, 20*s);
-    // Right leg
-    g.fillEllipse(cx + 10*s, cy + 4*s, 8*s, 20*s);
-    // Arch body connecting them
-    g.fillEllipse(cx, cy - 4*s, 28*s, 22*s);
-  }
-
-  // Helper: inner arch highlight layer
-  _kiroArchInner(g, cx, cy, s) {
-    g.fillStyle(0x42a5f5, 0.6);
-    g.fillEllipse(cx - 8*s, cy, 6*s, 18*s);
-    g.fillEllipse(cx + 8*s, cy, 6*s, 18*s);
-    g.fillEllipse(cx, cy - 5*s, 22*s, 18*s);
-  }
-
-  _drawSpider(cx, cy, big) {
-    const g = this.entityGraphics, s = big ? 1.5 : 1.0, t = Date.now();
-    const lw = Math.sin(t * 0.01) * 3 * s;
-    // glow
-    g.fillStyle(0x1b5e20, 0.2); g.fillCircle(cx, cy, 20*s);
-    // 8 legs with elbow bends
-    g.lineStyle(2*s, 0x1a1a1a, 1);
-    const legs = [
-      [cx-6*s,cy-2*s, cx-14*s,cy-8*s+lw,  cx-20*s,cy-4*s+lw],
-      [cx-6*s,cy,     cx-15*s,cy+lw,       cx-21*s,cy+4*s],
-      [cx-6*s,cy+2*s, cx-14*s,cy+8*s-lw,  cx-18*s,cy+12*s],
-      [cx-6*s,cy+4*s, cx-12*s,cy+10*s,    cx-14*s,cy+16*s],
-      [cx+6*s,cy-2*s, cx+14*s,cy-8*s-lw,  cx+20*s,cy-4*s-lw],
-      [cx+6*s,cy,     cx+15*s,cy-lw,       cx+21*s,cy+4*s],
-      [cx+6*s,cy+2*s, cx+14*s,cy+8*s+lw,  cx+18*s,cy+12*s],
-      [cx+6*s,cy+4*s, cx+12*s,cy+10*s,    cx+14*s,cy+16*s],
-    ];
-    for (const [x1,y1,mx,my,x2,y2] of legs) {
-      g.lineBetween(x1,y1,mx,my); g.lineBetween(mx,my,x2,y2);
+    
+    // ── HUGE kawaii eyes (◕‿◕) ────────────────────────────────────────────────
+    let eye1X, eye1Y, eye2X, eye2Y;
+    const eyeSize = 6; // Much bigger!
+    const eyeOffsetY = baseY - 6;
+    const blink = Math.sin(t * 0.002); // Slow blink
+    const isBlinking = blink > 0.97; // Occasional blink
+    
+    // Eye position based on direction
+    if (facing === 'LEFT') {
+      eye1X = cx - 6; eye1Y = eyeOffsetY;
+      eye2X = cx + 3; eye2Y = eyeOffsetY;
+    } else if (facing === 'RIGHT') {
+      eye1X = cx - 3; eye1Y = eyeOffsetY;
+      eye2X = cx + 6; eye2Y = eyeOffsetY;
+    } else {
+      eye1X = cx - 5; eye1Y = eyeOffsetY;
+      eye2X = cx + 5; eye2Y = eyeOffsetY;
     }
-    // abdomen
-    g.fillStyle(0x1b5e20, 1); g.fillEllipse(cx+4*s, cy+4*s, 18*s, 16*s);
-    g.fillStyle(0x2e7d32, 0.6); g.fillEllipse(cx+4*s, cy+2*s, 10*s, 8*s);
-    g.fillStyle(0x000000, 0.35);
-    for (let i=0;i<3;i++) g.fillEllipse(cx+4*s, cy+i*4*s, 4*s, 2*s);
-    g.fillStyle(0x66bb6a, 0.25); g.fillEllipse(cx+2*s, cy+1*s, 6*s, 5*s);
-    // hourglass marking (like black widow)
-    g.fillStyle(0xff1744, 0.8); g.fillEllipse(cx+4*s, cy+5*s, 5*s, 3*s);
-    // cephalothorax
-    g.fillStyle(0x212121, 1); g.fillEllipse(cx-3*s, cy, 12*s, 10*s);
-    g.fillStyle(0x424242, 0.4); g.fillEllipse(cx-4*s, cy-1*s, 7*s, 5*s);
-    // 8 eyes
-    g.fillStyle(0x00e676, 1);
-    const eyes = [[-6,-4],[-4,-5],[-2,-5],[0,-4],[-5,-2],[-3,-3],[-1,-3],[1,-2]];
-    for (const [ex,ey] of eyes) g.fillCircle(cx+ex*s, cy+ey*s, 1.2*s);
-    // chelicerae/fangs
-    g.fillStyle(0x4caf50, 1);
-    g.fillTriangle(cx-8*s,cy+3*s, cx-6*s,cy+3*s, cx-7*s,cy+7*s);
-    g.fillTriangle(cx-5*s,cy+3*s, cx-3*s,cy+3*s, cx-4*s,cy+7*s);
-    g.fillStyle(0x1b5e20, 1);
-    g.fillCircle(cx-7*s, cy+6*s, 1.5*s); g.fillCircle(cx-4*s, cy+6*s, 1.5*s);
-    if (big) { g.fillStyle(0x00c853, 0.12+Math.sin(t*0.009)*0.1); g.fillCircle(cx, cy, 28); }
-  }
-
-  // ── AWS Enemies (level 1) ─────────────────────────────────────────────────────
-  _drawAWSEnemy(cx, cy, gx, gy) {
-    const variant = (gx * 3 + gy * 7) % 8;
-    switch (variant) {
-      case 0: this._iconLambda(cx, cy);     break;
-      case 1: this._iconAPIGateway(cx, cy); break;
-      case 2: this._iconS3(cx, cy);         break;
-      case 3: this._iconDynamo(cx, cy);     break;
-      case 4: this._iconKinesis(cx, cy);    break;
-      case 5: this._iconIAM(cx, cy);        break;
-      case 6: this._iconCloudWatch(cx, cy); break;
-      case 7: this._iconSNS(cx, cy);        break;
-    }
-  }
-
-  _badge(cx, cy, bg, shadow) {
-    const g = this.entityGraphics, r = 15, d = 3;
-    g.fillStyle(shadow, 0.9);
-    g.fillRoundedRect(cx-r+d, cy-r+d, r*2, r*2, 6);
-    g.fillStyle(bg, 1);
-    g.fillRoundedRect(cx-r, cy-r, r*2, r*2, 6);
-    g.fillStyle(0xffffff, 0.20);
-    g.fillRoundedRect(cx-r, cy-r, r*2, 6, { tl:6, tr:6, bl:0, br:0 });
-    g.fillStyle(0xffffff, 0.10);
-    g.fillRoundedRect(cx-r, cy-r, 5, r*2, { tl:6, tr:0, bl:6, br:0 });
-    g.fillStyle(0x000000, 0.18);
-    g.fillRoundedRect(cx-r, cy+r-5, r*2, 5, { tl:0, tr:0, bl:6, br:6 });
-  }
-
-  // Lambda — orange, λ
-  _iconLambda(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xe8651a, 0x7a2e00);
-    g.lineStyle(3, 0xffffff, 1);
-    g.lineBetween(cx-7, cy-8, cx-1, cy+8);
-    g.lineBetween(cx-1, cy+8, cx+7, cy-8);
-    g.lineBetween(cx-7, cy-8, cx-3, cy-8);
-    this._smile(cx, cy+11);
-  }
-
-  // API Gateway — orange, </>
-  _iconAPIGateway(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xe8651a, 0x7a2e00);
-    g.lineStyle(2.5, 0xffffff, 1);
-    g.lineBetween(cx-4, cy-7, cx-9, cy); g.lineBetween(cx-9, cy, cx-4, cy+7);
-    g.lineBetween(cx+4, cy-7, cx+9, cy); g.lineBetween(cx+9, cy, cx+4, cy+7);
-    g.lineBetween(cx+3, cy-7, cx-3, cy+7);
-    this._smile(cx, cy+11);
-  }
-
-  // S3 — green, open bucket
-  _iconS3(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0x3f8624, 0x1a4a0a);
-    g.fillStyle(0xffffff, 1);
-    g.fillRect(cx-8, cy-5, 16, 13);
-    g.fillEllipse(cx, cy+8, 16, 6);
-    g.fillStyle(0x3f8624, 1);
-    g.fillEllipse(cx, cy-5, 16, 6);
-    g.lineStyle(2, 0xffffff, 1);
-    g.strokeEllipse(cx, cy-5, 16, 6);
-    g.fillStyle(0x3f8624, 0.5);
-    g.fillRect(cx-8, cy-1, 16, 2);
-    this._smile(cx, cy+11);
-  }
-
-  // DynamoDB — blue, stacked cylinders
-  _iconDynamo(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0x1a6faf, 0x0a2e55);
-    const cyl = (y, h) => {
+    
+    if (!isBlinking) {
+      // Eye whites (large circles)
+      g.fillStyle(0xffffff, 0.95);
+      g.fillCircle(eye1X, eye1Y, eyeSize);
+      g.fillCircle(eye2X, eye2Y, eyeSize);
+      
+      // Eye outer ring (purple)
+      g.lineStyle(1, 0xb39ddb, 0.5);
+      g.strokeCircle(eye1X, eye1Y, eyeSize);
+      g.strokeCircle(eye2X, eye2Y, eyeSize);
+      
+      // Pupils (big and shiny - classic anime style)
+      g.fillStyle(0x7c4dff, 1);
+      g.fillCircle(eye1X, eye1Y + 1, eyeSize * 0.65);
+      g.fillCircle(eye2X, eye2Y + 1, eyeSize * 0.65);
+      
+      // Inner pupil
+      g.fillStyle(0x5e35b1, 1);
+      g.fillCircle(eye1X, eye1Y + 1, eyeSize * 0.45);
+      g.fillCircle(eye2X, eye2Y + 1, eyeSize * 0.45);
+      
+      // Sparkle highlights (キラキラ)
       g.fillStyle(0xffffff, 1);
-      g.fillRect(cx-7, y, 14, h);
-      g.fillEllipse(cx, y, 14, 5);
-      g.fillStyle(0x1a6faf, 1);
-      g.fillEllipse(cx, y+h, 14, 5);
-      g.lineStyle(1.5, 0xffffff, 1);
-      g.strokeEllipse(cx, y+h, 14, 5);
-    };
-    cyl(cy-11, 5); cyl(cy-3, 5); cyl(cy+5, 4);
-    this._smile(cx, cy+12);
-  }
-
-  // Kinesis — orange, streaming waves + play arrow
-  _iconKinesis(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xe8651a, 0x7a2e00);
-    g.lineStyle(2.5, 0xffffff, 1);
-    for (let i = 0; i < 3; i++) {
-      const y = cy-6+i*5;
-      g.beginPath(); g.arc(cx-4, y, 4, Math.PI*1.5, Math.PI*0.5, false); g.strokePath();
-      g.beginPath(); g.arc(cx+4, y, 4, Math.PI*0.5, Math.PI*1.5, false); g.strokePath();
+      g.fillCircle(eye1X - 2, eye1Y - 1, 2.5);
+      g.fillCircle(eye2X - 2, eye2Y - 1, 2.5);
+      g.fillCircle(eye1X + 1.5, eye1Y + 2, 1.2);
+      g.fillCircle(eye2X + 1.5, eye2Y + 2, 1.2);
+      
+      // Tiny star sparkle
+      g.fillStyle(0xffffff, 0.8);
+      g.fillCircle(eye1X + 3, eye1Y - 2, 0.8);
+      g.fillCircle(eye2X + 3, eye2Y - 2, 0.8);
+    } else {
+      // Blinking (cute horizontal lines)
+      g.lineStyle(2, 0x7c4dff, 0.9);
+      g.lineBetween(eye1X - 4, eye1Y, eye1X + 4, eye1Y);
+      g.lineBetween(eye2X - 4, eye2Y, eye2X + 4, eye2Y);
     }
-    g.fillStyle(0xffffff, 1);
-    g.fillTriangle(cx+5, cy-5, cx+5, cy+5, cx+11, cy);
-    this._smile(cx, cy+11);
-  }
-
-  // IAM — red, shield with lock
-  _iconIAM(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xdd344c, 0x7a0010);
-    g.fillStyle(0xffffff, 1);
-    g.fillTriangle(cx, cy+10, cx-9, cy-4, cx+9, cy-4);
-    g.fillRect(cx-9, cy-10, 18, 8);
-    g.fillStyle(0xdd344c, 1);
-    g.fillRoundedRect(cx-4, cy-3, 8, 7, 2);
-    g.lineStyle(2, 0xdd344c, 1);
-    g.beginPath(); g.arc(cx, cy-4, 3, Math.PI, 0, false); g.strokePath();
-    g.fillStyle(0xffffff, 1);
-    g.fillCircle(cx, cy, 1.5);
-    g.fillRect(cx-1, cy, 2, 3);
-    this._smile(cx, cy+11);
-  }
-
-  // CloudWatch — pink, magnifier with cloud
-  _iconCloudWatch(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xe7157b, 0x7a0040);
-    g.lineStyle(2.5, 0xffffff, 1);
-    g.strokeCircle(cx-2, cy-3, 8);
-    g.lineStyle(3, 0xffffff, 1);
-    g.lineBetween(cx+4, cy+3, cx+9, cy+9);
-    g.fillStyle(0xffffff, 1);
-    g.fillCircle(cx-4, cy-2, 2.5); g.fillCircle(cx-1, cy-4, 3); g.fillCircle(cx+2, cy-2, 2.5);
-    g.fillRect(cx-4, cy-2, 9, 3);
-    this._smile(cx, cy+11);
-  }
-
-  // SNS — pink, funnel/filter
-  _iconSNS(cx, cy) {
-    const g = this.entityGraphics;
-    this._badge(cx, cy, 0xe7157b, 0x7a0040);
-    g.fillStyle(0xffffff, 1);
-    g.fillTriangle(cx-9, cy-8, cx+9, cy-8, cx+3, cy);
-    g.fillTriangle(cx-9, cy-8, cx-3, cy, cx+3, cy);
-    g.fillRect(cx-2, cy, 4, 8);
-    g.fillCircle(cx+7, cy-10, 3);
-    g.fillStyle(0xe7157b, 1);
-    g.fillCircle(cx+7, cy-10, 1.5);
-    this._smile(cx, cy+11);
-  }
-
-  // AWS smile-arrow
-  _smile(cx, cy) {
-    const g = this.entityGraphics;
-    g.lineStyle(1.8, 0xffffff, 0.85);
+    
+    // ── Kawaii blush (✿◠‿◠) ───────────────────────────────────────────────────
+    g.fillStyle(0xf8bbd0, 0.6);
+    g.fillCircle(cx - 11, baseY + 2, 3);
+    g.fillCircle(cx + 11, baseY + 2, 3);
+    
+    // Extra blush shine
+    g.fillStyle(0xffebee, 0.5);
+    g.fillCircle(cx - 11, baseY + 1, 2);
+    g.fillCircle(cx + 11, baseY + 1, 2);
+    
+    // ── Cute smile (◕‿◕) ──────────────────────────────────────────────────────
+    const smileY = baseY + 4;
+    
+    // Draw curved smile using arc (simple kawaii smile)
+    g.lineStyle(1.5, 0x9575cd, 0.9);
     g.beginPath();
-    g.arc(cx, cy-1, 7, 0.3, Math.PI-0.3, false);
+    g.arc(cx, smileY - 1, 4, 0.3, Math.PI - 0.3, false);
     g.strokePath();
-    const ex = cx + Math.cos(Math.PI-0.3)*7;
-    const ey = cy-1 + Math.sin(Math.PI-0.3)*7;
-    g.fillStyle(0xffffff, 0.85);
-    g.fillTriangle(ex-1, ey-3, ex+4, ey+1, ex-1, ey+3);
+    
+    // ── Sparkle particles (キラキラ) ──────────────────────────────────────────
+    for (let i = 0; i < 4; i++) {
+      const angle = (i / 4) * Math.PI * 2 + (t * 0.002);
+      const dist = r + 10 + Math.sin(t * 0.004 + i) * 3;
+      const px = cx + Math.cos(angle) * dist;
+      const py = baseY + Math.sin(angle) * dist * 0.5;
+      const sparklePhase = Math.sin(t * 0.006 + i * 1.5);
+      const sparkleAlpha = 0.5 + sparklePhase * 0.4;
+      
+      // Star sparkle shape
+      if (sparklePhase > 0) {
+        g.fillStyle(0xf3e5f5, sparkleAlpha);
+        g.fillCircle(px, py, 2.5);
+        g.fillStyle(0xffffff, sparkleAlpha * 0.8);
+        g.fillCircle(px, py, 1.5);
+        
+        // Star points
+        g.fillStyle(0xffffff, sparkleAlpha * 0.6);
+        g.fillCircle(px - 2, py, 0.8);
+        g.fillCircle(px + 2, py, 0.8);
+        g.fillCircle(px, py - 2, 0.8);
+        g.fillCircle(px, py + 2, 0.8);
+      }
+    }
   }
+
+  // ── NEW MAZE ENEMIES ──────────────────────────────────────────────────────────
+  // SKELETON: Bone white, glowing red eyes, patrols and chases
+  _drawSkeleton(cx, cy) {
+    const g = this.entityGraphics;
+    const t = Date.now();
+    const bob = Math.sin(t * 0.005) * 3; // floating animation
+    const pulse = Math.sin(t * 0.008);
+    const baseY = cy - 10 + bob;
+
+    // Massive glowing aura - VERY VISIBLE
+    g.fillStyle(0xff0000, 0.12 + pulse * 0.08);
+    g.fillCircle(cx, baseY, 60);
+    g.fillStyle(0xff3030, 0.20 + pulse * 0.10);
+    g.fillCircle(cx, baseY, 45);
+    g.fillStyle(0xff6060, 0.25 + pulse * 0.12);
+    g.fillCircle(cx, baseY, 30);
+
+    // Ribcage (3D isometric)
+    g.fillStyle(0xf5f5f5, 1);
+    g.fillEllipse(cx, baseY, 28, 22);
+    g.fillStyle(0xe0e0e0, 1);
+    g.fillEllipse(cx + 3, baseY, 12, 22);
+
+    // Ribs (horizontal lines with gaps)
+    g.lineStyle(3, 0xbdbdbd, 1);
+    for (let i = -8; i <= 8; i += 5) {
+      g.lineBetween(cx - 10, baseY + i, cx - 2, baseY + i);
+      g.lineBetween(cx + 2, baseY + i, cx + 10, baseY + i);
+    }
+
+    // Spine highlight
+    g.lineStyle(2, 0xdcdcdc, 0.8);
+    g.lineBetween(cx, baseY - 10, cx, baseY + 10);
+
+    // Skull (elevated above ribcage)
+    const skullY = baseY - 18;
+    
+    // Skull base
+    g.fillStyle(0xffffff, 1);
+    g.fillEllipse(cx, skullY, 22, 20);
+    g.fillStyle(0xf5f5f5, 1);
+    g.fillEllipse(cx + 2, skullY, 18, 18);
+    
+    // Jaw
+    g.fillStyle(0xeeeeee, 1);
+    g.fillEllipse(cx, skullY + 10, 14, 8);
+    g.lineStyle(1.5, 0xbdbdbd, 1);
+    g.lineBetween(cx - 6, skullY + 8, cx - 6, skullY + 12);
+    g.lineBetween(cx, skullY + 8, cx, skullY + 12);
+    g.lineBetween(cx + 6, skullY + 8, cx + 6, skullY + 12);
+
+    // Eye sockets - GLOWING RED (VERY VISIBLE!)
+    g.fillStyle(0x000000, 1);
+    g.fillEllipse(cx - 7, skullY - 2, 8, 10);
+    g.fillEllipse(cx + 7, skullY - 2, 8, 10);
+    
+    // INTENSE RED GLOW in eyes
+    g.fillStyle(0xff0000, 1);
+    g.fillCircle(cx - 7, skullY - 2, 5);
+    g.fillCircle(cx + 7, skullY - 2, 5);
+    g.fillStyle(0xff5252, 1);
+    g.fillCircle(cx - 7, skullY - 2, 3.5);
+    g.fillCircle(cx + 7, skullY - 2, 3.5);
+    g.fillStyle(0xff8a80, 1);
+    g.fillCircle(cx - 7, skullY - 3, 2);
+    g.fillCircle(cx + 7, skullY - 3, 2);
+
+    // Nose cavity
+    g.fillStyle(0x000000, 1);
+    g.fillTriangle(cx - 2, skullY + 2, cx + 2, skullY + 2, cx, skullY + 6);
+
+    // Arms (bone segments)
+    g.fillStyle(0xeeeeee, 1);
+    // Left arm
+    g.fillEllipse(cx - 14, baseY - 5, 5, 16);
+    g.fillEllipse(cx - 18, baseY + 4, 4, 10);
+    // Right arm
+    g.fillEllipse(cx + 14, baseY - 5, 5, 16);
+    g.fillEllipse(cx + 18, baseY + 4, 4, 10);
+
+    // Shoulder joints
+    g.fillStyle(0xf5f5f5, 1);
+    g.fillCircle(cx - 12, baseY - 8, 4);
+    g.fillCircle(cx + 12, baseY - 8, 4);
+
+    // Bright outline for maximum visibility
+    g.lineStyle(2, 0xffffff, 0.7);
+    g.strokeCircle(cx, baseY, 15);
+  }
+
+  // MINOTAUR: Massive bull-headed warrior, orange-brown, very intimidating
+  _drawMinotaur(cx, cy) {
+    const g = this.entityGraphics;
+    const t = Date.now();
+    const breathe = Math.sin(t * 0.004) * 2;
+    const pulse = Math.sin(t * 0.006);
+    const baseY = cy - 12;
+
+    // Massive presence aura - VERY VISIBLE
+    g.fillStyle(0xff6f00, 0.15 + pulse * 0.10);
+    g.fillCircle(cx, baseY, 70);
+    g.fillStyle(0xff8f00, 0.22 + pulse * 0.12);
+    g.fillCircle(cx, baseY, 50);
+    g.fillStyle(0xffab00, 0.28 + pulse * 0.14);
+    g.fillCircle(cx, baseY, 35);
+
+    // Body (massive muscular torso)
+    g.fillStyle(0x8d6e63, 1);
+    g.fillEllipse(cx, baseY + 8, 32, 28);
+    g.fillStyle(0xa1887f, 0.6);
+    g.fillEllipse(cx - 5, baseY + 5, 14, 25);
+
+    // Chest muscles definition
+    g.lineStyle(3, 0x6d4c41, 0.8);
+    g.lineBetween(cx, baseY - 2, cx, baseY + 18);
+    g.lineStyle(2, 0x6d4c41, 0.6);
+    g.lineBetween(cx - 10, baseY + 5, cx + 10, baseY + 5);
+
+    // Arms (powerful)
+    g.fillStyle(0x795548, 1);
+    // Left arm
+    g.fillEllipse(cx - 20, baseY + 8, 10, 26);
+    g.fillStyle(0x8d6e63, 0.7);
+    g.fillCircle(cx - 20, baseY, 7);
+    // Right arm
+    g.fillStyle(0x795548, 1);
+    g.fillEllipse(cx + 20, baseY + 8, 10, 26);
+    g.fillStyle(0x8d6e63, 0.7);
+    g.fillCircle(cx + 20, baseY, 7);
+
+    // Hands/fists
+    g.fillStyle(0x5d4037, 1);
+    g.fillCircle(cx - 20, baseY + 20, 6);
+    g.fillCircle(cx + 20, baseY + 20, 6);
+
+    // Bull head (large and menacing)
+    const headY = baseY - 15;
+    
+    // Neck (thick)
+    g.fillStyle(0x8d6e63, 1);
+    g.fillEllipse(cx, baseY - 5, 18, 12);
+
+    // Head base
+    g.fillStyle(0x6d4c41, 1);
+    g.fillEllipse(cx, headY, 28, 24);
+    g.fillStyle(0x795548, 0.8);
+    g.fillEllipse(cx - 3, headY, 22, 22);
+
+    // Snout/muzzle (protruding)
+    g.fillStyle(0x8d6e63, 1);
+    g.fillEllipse(cx, headY + 8, 22, 14);
+    g.fillStyle(0x9e9e9e, 1);
+    g.fillEllipse(cx, headY + 12, 12, 8);
+
+    // Nostrils (flaring, with steam effect)
+    g.fillStyle(0x424242, 1);
+    g.fillEllipse(cx - 4, headY + 12, 3, 4);
+    g.fillEllipse(cx + 4, headY + 12, 3, 4);
+    
+    // Steam/breath from nostrils
+    g.fillStyle(0xffffff, 0.3 + pulse * 0.2);
+    g.fillCircle(cx - 5, headY + 15 + breathe, 4);
+    g.fillCircle(cx + 5, headY + 15 + breathe, 4);
+
+    // Eyes - GLOWING ORANGE (VERY VISIBLE!)
+    g.fillStyle(0xff6f00, 1);
+    g.fillCircle(cx - 8, headY - 3, 6);
+    g.fillCircle(cx + 8, headY - 3, 6);
+    g.fillStyle(0xffab00, 1);
+    g.fillCircle(cx - 8, headY - 3, 4);
+    g.fillCircle(cx + 8, headY - 3, 4);
+    g.fillStyle(0xffd54f, 1);
+    g.fillCircle(cx - 8, headY - 4, 2);
+    g.fillCircle(cx + 8, headY - 4, 2);
+
+    // Horns (large, curved, intimidating)
+    g.lineStyle(6, 0x424242, 1);
+    // Left horn
+    g.beginPath();
+    g.moveTo(cx - 14, headY - 8);
+    g.lineTo(cx - 22, headY - 18);
+    g.lineTo(cx - 18, headY - 20);
+    g.strokePath();
+    // Right horn
+    g.beginPath();
+    g.moveTo(cx + 14, headY - 8);
+    g.lineTo(cx + 22, headY - 18);
+    g.lineTo(cx + 18, headY - 20);
+    g.strokePath();
+
+    // Horn highlights
+    g.lineStyle(2, 0x9e9e9e, 0.9);
+    g.lineBetween(cx - 14, headY - 8, cx - 20, headY - 18);
+    g.lineBetween(cx + 14, headY - 8, cx + 20, headY - 18);
+
+    // Ear tags
+    g.fillStyle(0x8d6e63, 1);
+    g.fillTriangle(cx - 18, headY - 5, cx - 16, headY - 10, cx - 14, headY - 5);
+    g.fillTriangle(cx + 14, headY - 5, cx + 16, headY - 10, cx + 18, headY - 5);
+
+    // Bright outline for maximum visibility
+    g.lineStyle(2, 0xffd54f, 0.6);
+    g.strokeCircle(cx, baseY, 20);
+  }
+
+  // SPECTER: Ghostly apparition, cyan-purple, ethereal and eerie
+  _drawSpecter(cx, cy) {
+    const g = this.entityGraphics;
+    const t = Date.now();
+    const float = Math.sin(t * 0.003) * 6;
+    const pulse1 = Math.sin(t * 0.007);
+    const pulse2 = Math.sin(t * 0.011);
+    const shimmer = Math.sin(t * 0.013) * 0.2;
+    const baseY = cy - 15 + float;
+
+    // Ethereal aura layers - VERY VISIBLE with pulsing effect
+    g.fillStyle(0x00bcd4, 0.10 + pulse1 * 0.08);
+    g.fillCircle(cx, baseY, 80);
+    g.fillStyle(0x26c6da, 0.18 + pulse1 * 0.10);
+    g.fillCircle(cx, baseY, 60);
+    g.fillStyle(0x4dd0e1, 0.25 + pulse2 * 0.12);
+    g.fillCircle(cx, baseY, 45);
+    g.fillStyle(0x80deea, 0.30 + pulse1 * 0.15);
+    g.fillCircle(cx, baseY, 30);
+
+    // Main ghostly form (ethereal, semi-transparent)
+    g.fillStyle(0xe1f5fe, 0.85 + shimmer);
+    g.fillEllipse(cx, baseY, 30, 40);
+    
+    // Gradient-like layers for depth
+    g.fillStyle(0xb3e5fc, 0.7 + shimmer);
+    g.fillEllipse(cx - 3, baseY, 24, 36);
+    g.fillStyle(0x81d4fa, 0.6 + shimmer);
+    g.fillEllipse(cx - 5, baseY, 18, 32);
+    g.fillStyle(0x4fc3f7, 0.5 + shimmer);
+    g.fillEllipse(cx - 6, baseY + 2, 14, 28);
+
+    // Wispy trails (flowing fabric-like)
+    g.fillStyle(0xb3e5fc, 0.4 + pulse2 * 0.2);
+    const wispY = baseY + 20;
+    g.fillEllipse(cx - 12, wispY + pulse1 * 3, 8, 20);
+    g.fillEllipse(cx, wispY + pulse2 * 4, 10, 24);
+    g.fillEllipse(cx + 12, wispY + pulse1 * 3, 8, 20);
+    
+    // Flowing ends (tattered)
+    g.fillStyle(0x81d4fa, 0.3 + shimmer);
+    for (let i = -1; i <= 1; i++) {
+      const offsetX = cx + i * 12;
+      const offsetY = wispY + 18 + Math.sin(t * 0.008 + i) * 4;
+      g.fillEllipse(offsetX, offsetY, 6, 10);
+    }
+
+    // Hood/Head area
+    const headY = baseY - 12;
+    g.fillStyle(0xe1f5fe, 0.9);
+    g.fillEllipse(cx, headY, 24, 20);
+    g.fillStyle(0xb3e5fc, 0.8);
+    g.fillEllipse(cx - 2, headY, 20, 18);
+
+    // Face - dark void within hood
+    g.fillStyle(0x01579b, 0.6);
+    g.fillEllipse(cx, headY + 2, 16, 14);
+
+    // Eyes - GLOWING CYAN (VERY VISIBLE AND EERIE!)
+    g.fillStyle(0x00bcd4, 1);
+    g.fillCircle(cx - 6, headY, 7);
+    g.fillCircle(cx + 6, headY, 7);
+    g.fillStyle(0x00e5ff, 1);
+    g.fillCircle(cx - 6, headY, 5);
+    g.fillCircle(cx + 6, headY, 5);
+    g.fillStyle(0x80deea, 1);
+    g.fillCircle(cx - 6, headY, 3);
+    g.fillCircle(cx + 6, headY, 3);
+    g.fillStyle(0xffffff, 0.9);
+    g.fillCircle(cx - 6, headY - 1, 1.5);
+    g.fillCircle(cx + 6, headY - 1, 1.5);
+
+    // Eye glow rays (radiating outward)
+    g.lineStyle(2, 0x00e5ff, 0.5 + pulse1 * 0.3);
+    for (let i = 0; i < 8; i++) {
+      const angle = (i / 8) * Math.PI * 2 + t * 0.001;
+      const rayLen = 12 + pulse2 * 3;
+      g.lineBetween(
+        cx - 6, headY,
+        cx - 6 + Math.cos(angle) * rayLen,
+        headY + Math.sin(angle) * rayLen
+      );
+      g.lineBetween(
+        cx + 6, headY,
+        cx + 6 + Math.cos(angle) * rayLen,
+        headY + Math.sin(angle) * rayLen
+      );
+    }
+
+    // Ethereal particles floating around
+    for (let i = 0; i < 6; i++) {
+      const angle = (i / 6) * Math.PI * 2 + t * 0.002;
+      const dist = 25 + Math.sin(t * 0.004 + i) * 8;
+      const px = cx + Math.cos(angle) * dist;
+      const py = baseY + Math.sin(angle) * dist * 0.6;
+      g.fillStyle(0x80deea, 0.6 + pulse2 * 0.3);
+      g.fillCircle(px, py, 3);
+    }
+
+    // Bright outline for maximum visibility
+    g.lineStyle(2, 0x00e5ff, 0.8 + pulse1 * 0.2);
+    g.strokeCircle(cx, baseY, 18);
+    
+    // Second outer glow ring
+    g.lineStyle(1, 0x80deea, 0.5 + pulse2 * 0.3);
+    g.strokeCircle(cx, baseY, 25);
+  }
+
+  // ── OLD ENEMY FUNCTIONS REMOVED ──────────────────────────────────────────────
+  // All old enemy rendering code (bats, wolves, spiders, AWS logos) has been
+  // removed and replaced with the new intelligent maze enemies:
+  // - _drawSkeleton() - Red glowing eyes, patrol and chase
+  // - _drawMinotaur() - Orange glowing eyes, hunter with pathfinding
+  // - _drawSpecter() - Cyan glowing eyes, teleporting ghost
 
   // ── Torch ─────────────────────────────────────────────────────────────────────
   _drawTorch(cx, cy) {
@@ -980,49 +1274,251 @@ export default class IsometricRenderer {
   _drawTrap(cx, cy, colorKey) {
     const g = this.entityGraphics, t = Date.now();
     const pulse = Math.sin(t * 0.006) * 0.15;
+    const fastPulse = Math.sin(t * 0.012) * 0.2;
 
     if (colorKey === 'TRAP_PROJECTILE') {
-      // Glowing orb projectile
-      g.fillStyle(0xff6f00, 0.2+pulse); g.fillCircle(cx, cy, 14);
-      g.fillStyle(0xff3d00, 1); g.fillCircle(cx, cy, 9);
-      g.fillStyle(0xff6d00, 1); g.fillCircle(cx, cy, 7);
-      g.fillStyle(0xffca28, 1); g.fillCircle(cx, cy, 4);
-      g.fillStyle(0xffffff, 0.9); g.fillCircle(cx-2, cy-2, 2);
-      // trail
-      g.fillStyle(0xff6d00, 0.4); g.fillEllipse(cx-6, cy, 8, 5);
-      g.fillStyle(0xffca28, 0.2); g.fillEllipse(cx-10, cy, 6, 3);
-    } else if (colorKey === 'TRAP_PENDULUM') {
-      // Spiked ball on chain
-      g.fillStyle(0xb71c1c, 0.2+pulse); g.fillCircle(cx, cy, 14);
-      // chain link
-      g.lineStyle(2, 0x757575, 1); g.lineBetween(cx, cy-14, cx, cy-8);
-      // ball shadow
-      g.fillStyle(0x7f0000, 0.8); g.fillCircle(cx+2, cy+2, 10);
-      // ball
-      g.fillStyle(0xc62828, 1); g.fillCircle(cx, cy, 10);
-      g.fillStyle(0xef5350, 0.6); g.fillCircle(cx, cy, 8);
-      // spikes
-      for (let i=0;i<6;i++) {
-        const a = (i/6)*Math.PI*2;
-        g.fillStyle(0x9e0000, 1);
-        g.fillTriangle(cx+Math.cos(a)*8, cy+Math.sin(a)*8, cx+Math.cos(a+0.3)*12, cy+Math.sin(a+0.3)*12, cx+Math.cos(a-0.3)*12, cy+Math.sin(a-0.3)*12);
+      // Enhanced blazing projectile with beautiful trail
+      const trailLen = 8;
+      const rotation = t * 0.004;
+      
+      // Extended glowing trail
+      for (let i = trailLen; i >= 0; i--) {
+        const alpha = (1 - i / trailLen) * 0.5;
+        const offset = i * 3.5;
+        const size = 15 - i * 1.3;
+        g.fillStyle(0xff6f00, alpha * 0.4);
+        g.fillCircle(cx - offset, cy, size + 4);
+        g.fillStyle(0xff9d00, alpha);
+        g.fillCircle(cx - offset, cy, size);
       }
-      g.fillStyle(0xffffff, 0.3); g.fillCircle(cx-3, cy-3, 3);
+      
+      // Outer energy field
+      g.fillStyle(0xff6f00, 0.15 + pulse);
+      g.fillCircle(cx, cy, 26);
+      g.fillStyle(0xff8f00, 0.25 + pulse);
+      g.fillCircle(cx, cy, 20);
+      
+      // Main projectile core (layered for depth)
+      g.fillStyle(0xbf360c, 1); g.fillCircle(cx, cy, 12);
+      g.fillStyle(0xff3d00, 1); g.fillCircle(cx, cy, 10);
+      g.fillStyle(0xff6d00, 1); g.fillCircle(cx, cy, 8);
+      g.fillStyle(0xff9800, 1); g.fillCircle(cx, cy, 6);
+      g.fillStyle(0xffca28, 1); g.fillCircle(cx, cy, 4.5);
+      g.fillStyle(0xffffff, 1); g.fillCircle(cx, cy, 2.5);
+      
+      // Dynamic highlight
+      g.fillStyle(0xffffff, 0.9);
+      g.fillCircle(cx - 3, cy - 3, 3);
+      
+      // Rotating energy sparks (more dramatic)
+      for (let i = 0; i < 8; i++) {
+        const angle = (i / 8) * Math.PI * 2 + rotation;
+        const dist = 12 + Math.sin(t * 0.008 + i) * 3;
+        const sx = cx + Math.cos(angle) * dist;
+        const sy = cy + Math.sin(angle) * dist * 0.6;
+        const sparkPulse = Math.sin(t * 0.01 + i * 0.5);
+        
+        g.fillStyle(0xffca28, 0.7 + sparkPulse * 0.3);
+        g.fillCircle(sx, sy, 3);
+        g.fillStyle(0xffffff, 0.8 + sparkPulse * 0.2);
+        g.fillCircle(sx, sy, 1.5);
+      }
+      
+      // Energy wisps
+      for (let i = 0; i < 4; i++) {
+        const angle = (i / 4) * Math.PI * 2 + rotation * 1.5;
+        const wispDist = 16 + Math.sin(t * 0.006 + i) * 4;
+        const wx = cx + Math.cos(angle) * wispDist;
+        const wy = cy + Math.sin(angle) * wispDist * 0.5;
+        g.fillStyle(0xff9800, 0.5);
+        g.fillCircle(wx, wy, 2.5);
+      }
+      
+    } else if (colorKey === 'TRAP_PENDULUM') {
+      // Beautiful deadly pendulum with dramatic swing
+      const swing = Math.sin(t * 0.0035) * 8;
+      const swingSpeed = Math.abs(Math.cos(t * 0.0035)) * 0.3;
+      
+      // Danger warning aura (pulsing)
+      g.fillStyle(0xb71c1c, 0.12 + pulse + swingSpeed);
+      g.fillCircle(cx, cy, 28);
+      g.fillStyle(0xd32f2f, 0.20 + pulse);
+      g.fillCircle(cx, cy, 22);
+      g.fillStyle(0xef5350, 0.28 + pulse);
+      g.fillCircle(cx, cy, 17);
+      
+      // Enhanced chain with metallic segments
+      const chainSegments = 5;
+      for (let i = 0; i < chainSegments; i++) {
+        const segY = cy - 18 + (i / chainSegments) * 8;
+        const segX = cx + (swing * (chainSegments - i) / chainSegments);
+        
+        g.lineStyle(3, 0x424242, 1);
+        g.lineBetween(
+          segX,
+          segY,
+          cx + (swing * (chainSegments - i - 1) / chainSegments),
+          segY + 8 / chainSegments
+        );
+        
+        // Chain links
+        g.fillStyle(0x616161, 1);
+        g.fillCircle(segX, segY, 2.5);
+        g.fillStyle(0x9e9e9e, 0.8);
+        g.fillCircle(segX, segY, 1.5);
+      }
+      
+      // Chain attachment point
+      g.fillStyle(0x212121, 1);
+      g.fillCircle(cx + swing, cy - 18, 5);
+      g.fillStyle(0x616161, 1);
+      g.fillCircle(cx + swing, cy - 18, 4);
+      g.fillStyle(0x9e9e9e, 0.7);
+      g.fillCircle(cx + swing, cy - 18, 2.5);
+      
+      // Ball shadow (dynamic with swing)
+      g.fillStyle(0x7f0000, 0.6);
+      g.fillEllipse(cx + swing * 0.3 + 3, cy + 4, 26, 12);
+      
+      // Main ball with metallic shading
+      g.fillStyle(0x7f0000, 1); g.fillCircle(cx, cy, 14);
+      g.fillStyle(0xc62828, 1); g.fillCircle(cx, cy, 12);
+      g.fillStyle(0xef5350, 0.85); g.fillCircle(cx - 1, cy - 1, 11);
+      g.fillStyle(0xd32f2f, 1); g.fillCircle(cx, cy, 10);
+      
+      // Metallic highlights
+      g.fillStyle(0xffffff, 0.5);
+      g.fillCircle(cx - 4, cy - 4, 5);
+      g.fillStyle(0xffffff, 0.3);
+      g.fillCircle(cx - 3, cy - 3, 3);
+      
+      // Enhanced deadly spikes (10 directions for more menacing look)
+      for (let i = 0; i < 10; i++) {
+        const a = (i / 10) * Math.PI * 2 + t * 0.001;
+        
+        // Spike shadow
+        g.fillStyle(0x7f0000, 0.6);
+        g.fillTriangle(
+          cx + Math.cos(a) * 10.5 + 1, cy + Math.sin(a) * 10.5 + 1,
+          cx + Math.cos(a + 0.18) * 16 + 1, cy + Math.sin(a + 0.18) * 16 + 1,
+          cx + Math.cos(a - 0.18) * 16 + 1, cy + Math.sin(a - 0.18) * 16 + 1
+        );
+        
+        // Main spike
+        g.fillStyle(0x9e0000, 1);
+        g.fillTriangle(
+          cx + Math.cos(a) * 10, cy + Math.sin(a) * 10,
+          cx + Math.cos(a + 0.18) * 15, cy + Math.sin(a + 0.18) * 15,
+          cx + Math.cos(a - 0.18) * 15, cy + Math.sin(a - 0.18) * 15
+        );
+        
+        // Spike edge highlight
+        g.fillStyle(0xd32f2f, 0.8);
+        g.fillTriangle(
+          cx + Math.cos(a) * 10, cy + Math.sin(a) * 10,
+          cx + Math.cos(a + 0.12) * 13, cy + Math.sin(a + 0.12) * 13,
+          cx + Math.cos(a - 0.12) * 13, cy + Math.sin(a - 0.12) * 13
+        );
+        
+        // Sharp tip highlight
+        g.fillStyle(0xff5252, 0.8);
+        g.fillCircle(
+          cx + Math.cos(a) * 15,
+          cy + Math.sin(a) * 15,
+          1.5
+        );
+      }
+      
     } else {
-      // MOVING_WALL / SPIKE — glowing blade
-      g.fillStyle(0xff5722, 0.2+pulse); g.fillCircle(cx, cy, 14);
-      g.fillStyle(0xbf360c, 0.8); g.fillRect(cx-10+2, cy-10+2, 20, 20);
-      g.fillStyle(0xff5722, 1); g.fillRect(cx-10, cy-10, 20, 20);
-      g.fillStyle(0xff8a65, 0.5); g.fillRect(cx-10, cy-10, 8, 20);
-      g.fillStyle(0xffffff, 0.2); g.fillRect(cx-10, cy-10, 20, 5);
-      // spike tips
-      g.fillStyle(0xffffff, 0.8);
-      g.fillTriangle(cx, cy-10, cx-4, cy-6, cx+4, cy-6);
-      g.fillTriangle(cx, cy+10, cx-4, cy+6, cx+4, cy+6);
+      // MOVING_WALL / SPIKE — beautiful deadly blade with effects
+      const vibrate = Math.sin(t * 0.015) * 2;
+      const rotation = Math.sin(t * 0.008) * 0.1;
+      
+      // Danger warning aura (larger, more visible)
+      g.fillStyle(0xff5722, 0.15 + pulse);
+      g.fillCircle(cx, cy, 32);
+      g.fillStyle(0xff7043, 0.25 + pulse);
+      g.fillCircle(cx, cy, 24);
+      g.fillStyle(0xff8a65, 0.35 + pulse);
+      g.fillCircle(cx, cy, 18);
+      
+      // Motion blur/afterimage (trailing effect)
+      for (let i = 3; i >= 0; i--) {
+        const blurOffset = vibrate * (i / 3);
+        const blurAlpha = 0.15 * (1 - i / 3);
+        g.fillStyle(0xff5722, blurAlpha);
+        g.fillRect(cx - 13 + blurOffset, cy - 13, 26, 26);
+      }
+      
+      // Blade shadow (3D depth)
+      g.fillStyle(0xbf360c, 0.75);
+      g.fillRect(cx - 11 + vibrate + 2, cy - 11 + 2, 22, 22);
+      
+      // Main blade body (layered for depth)
+      g.fillStyle(0xd84315, 1);
+      g.fillRect(cx - 12 + vibrate, cy - 12, 24, 24);
+      g.fillStyle(0xff5722, 1);
+      g.fillRect(cx - 11 + vibrate, cy - 11, 22, 22);
+      
+      // Metallic gradient shading
+      g.fillStyle(0xff8a65, 0.7);
+      g.fillRect(cx - 11 + vibrate, cy - 11, 11, 22);
+      g.fillStyle(0xbf360c, 0.3);
+      g.fillRect(cx + vibrate, cy - 11, 11, 22);
+      
+      // Top shine
+      g.fillStyle(0xffffff, 0.35);
+      g.fillRect(cx - 11 + vibrate, cy - 11, 22, 8);
+      g.fillStyle(0xffccbc, 0.2);
+      g.fillRect(cx - 11 + vibrate, cy - 11, 22, 4);
+      
+      // Enhanced sharp spike tips (4 sides)
+      // Top spike
+      g.fillStyle(0xe64a19, 1);
+      g.fillTriangle(cx + vibrate, cy - 14, cx - 6 + vibrate, cy - 9, cx + 6 + vibrate, cy - 9);
+      g.fillStyle(0xff8a65, 0.8);
+      g.fillTriangle(cx + vibrate, cy - 14, cx - 4 + vibrate, cy - 10, cx + 4 + vibrate, cy - 10);
+      g.fillStyle(0xffffff, 0.9);
+      g.fillTriangle(cx + vibrate, cy - 14, cx - 2 + vibrate, cy - 11, cx + 2 + vibrate, cy - 11);
+      
+      // Bottom spike
+      g.fillStyle(0xe64a19, 1);
+      g.fillTriangle(cx + vibrate, cy + 14, cx - 6 + vibrate, cy + 9, cx + 6 + vibrate, cy + 9);
+      g.fillStyle(0xff8a65, 0.8);
+      g.fillTriangle(cx + vibrate, cy + 14, cx - 4 + vibrate, cy + 10, cx + 4 + vibrate, cy + 10);
+      g.fillStyle(0xffffff, 0.9);
+      g.fillTriangle(cx + vibrate, cy + 14, cx - 2 + vibrate, cy + 11, cx + 2 + vibrate, cy + 11);
+      
+      // Left spike
+      g.fillStyle(0xe64a19, 1);
+      g.fillTriangle(cx - 14 + vibrate, cy, cx - 9 + vibrate, cy - 6, cx - 9 + vibrate, cy + 6);
+      g.fillStyle(0xff8a65, 0.8);
+      g.fillTriangle(cx - 14 + vibrate, cy, cx - 10 + vibrate, cy - 4, cx - 10 + vibrate, cy + 4);
+      
+      // Right spike
+      g.fillStyle(0xe64a19, 1);
+      g.fillTriangle(cx + 14 + vibrate, cy, cx + 9 + vibrate, cy - 6, cx + 9 + vibrate, cy + 6);
+      g.fillStyle(0xff8a65, 0.8);
+      g.fillTriangle(cx + 14 + vibrate, cy, cx + 10 + vibrate, cy - 4, cx + 10 + vibrate, cy + 4);
+      
+      // Energy sparks at corners
+      const corners = [
+        {x: cx - 12 + vibrate, y: cy - 12},
+        {x: cx + 12 + vibrate, y: cy - 12},
+        {x: cx - 12 + vibrate, y: cy + 12},
+        {x: cx + 12 + vibrate, y: cy + 12}
+      ];
+      corners.forEach((corner, i) => {
+        const sparkPulse = Math.sin(t * 0.01 + i) * 0.3;
+        g.fillStyle(0xffca28, 0.6 + sparkPulse);
+        g.fillCircle(corner.x, corner.y, 3);
+        g.fillStyle(0xffffff, 0.8 + sparkPulse);
+        g.fillCircle(corner.x, corner.y, 1.5);
+      });
     }
   }
 
-  // ── Mine — dormant bomb that explodes after a 3-second countdown ─────────────
+  // ── Mine — dormant bomb that explodes after a 2-second countdown ─────────────
   drawMine(gx, gy, activated, timerMs) {
     const s  = tileToScreen(gx, gy);
     const cx = s.x + this.offsetX + TILE_W / 2;


### PR DESCRIPTION
- Corregir error de sintaxis en línea 188 de IsometricRenderer.js (destructuring)
- Añadir _wallGfx faltante en GameScene.js
- Separar renderizado de paredes en dos capas (back/front) para oclusión correcta
- Las paredes delante del jugador ahora lo ocultan correctamente
- Las paredes detrás del jugador se renderizan detrás del personaje
- Comparación de profundidad basada en posición isométrica (gx+gy)